### PR TITLE
Add error handling to patient sync; Add contacts index

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * If your environment is not set up to run a rails app, follow the installation instructions at https://guides.rubyonrails.org/getting_started.html#creating-a-new-rails-project-installing-rails.
 * For simplicity, this app uses a SQLite3 database so make sure that is installed.
-* Clone the repository, run `bundle`, and also make sure you run `rails db:seed` so you have data to work with.
+* Clone the repository, run `bundle`, and also make sure you run `rails db:migrate db:seed` so you have data to work with.
 * Run this rails app using `bin/dev` (we use Tailwind and that will auto-compile the CSS).
 * Visit localhost:3000 to see the instructions for the exercise.
 

--- a/app/components/contact_card_component.html.erb
+++ b/app/components/contact_card_component.html.erb
@@ -1,0 +1,5 @@
+ <%= render CardComponent.new do %>
+  <h5 class="mb-1 text-xl font-medium text-gray-900">
+    <%= render FullNameComponent.new(@contact) %>
+  </h5>
+<% end %>

--- a/app/components/contact_card_component.html.erb
+++ b/app/components/contact_card_component.html.erb
@@ -2,4 +2,10 @@
   <h5 class="mb-1 text-xl font-medium text-gray-900">
     <%= render FullNameComponent.new(@contact) %>
   </h5>
+
+  <div class="flex mt-4 space-x-3 md:mt-6">
+    <%= form_with url: patients_path(contact_id: @contact.id), method: :post do |form| %>
+      <%= form.button "Create Patient", class: "inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300" %>
+    <% end %>
+  </div>    
 <% end %>

--- a/app/components/contact_card_component.rb
+++ b/app/components/contact_card_component.rb
@@ -1,0 +1,5 @@
+class ContactCardComponent < ViewComponent::Base
+  def initialize(contact)
+    @contact = contact
+  end
+end

--- a/app/components/patient_card_component.html.erb
+++ b/app/components/patient_card_component.html.erb
@@ -1,0 +1,14 @@
+ <%= render CardComponent.new do %>
+  <%= render AvatarComponent.new(avatar_url: @patient.avatar_url) %>
+  <h5 class="mb-1 text-xl font-medium text-gray-900">
+    <%= render FullNameComponent.new(@patient) %>
+  </h5>
+  
+  <%= render TimestampComponent.new(@patient.sicklie_updated_at, "Not registered with Sicklie") %>
+
+  <div class="flex mt-4 space-x-3 md:mt-6">
+    <%= form_with url: sync_patient_path(@patient), method: :put do |form| %>
+      <%= form.button "Sync", class: "inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300" %>
+    <% end %>
+  </div>    
+<% end %>

--- a/app/components/patient_card_component.rb
+++ b/app/components/patient_card_component.rb
@@ -1,0 +1,5 @@
+class PatientCardComponent < ViewComponent::Base
+  def initialize(patient)
+    @patient = patient
+  end
+end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,6 +1,5 @@
 class ContactsController < ApplicationController
   def index
-    #TODO consider adding a composite index on first_name and last_name
     @contacts = Contact.include(:patient).all.order(:first_name, :last_name)
   end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,6 +1,6 @@
 class ContactsController < ApplicationController
   def index
     #TODO consider adding a composite index on first_name and last_name
-    @contacts = Contact.all.order(:first_name, :last_name)
+    @contacts = Contact.include(:patient).all.order(:first_name, :last_name)
   end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,6 @@
+class ContactsController < ApplicationController
+  def index
+    #TODO consider adding a composite index on first_name and last_name
+    @contacts = Contact.all.order(:first_name, :last_name)
+  end
+end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -8,17 +8,13 @@ class PatientsController < ApplicationController
   def create
     contact = Contact.find(params[:contact_id])
 
-    ApplicationRecord.transaction do
-      patient = contact.create_patient!({
-        first_name: contact.first_name,
-        last_name: contact.last_name,
-        avatar_url: Contact::DEFAULT_AVATAR_URL,
-      })
-      contact.save!
-  
-      flash[:info] = "Created patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
-    end
+    patient = contact.create_patient!({
+      first_name: contact.first_name,
+      last_name: contact.last_name,
+      avatar_url: Contact::DEFAULT_AVATAR_URL,
+    })
 
+    flash[:info] = "Created patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
 
     redirect_to controller: :contacts, action: :index
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -5,6 +5,24 @@ class PatientsController < ApplicationController
     @patients = Patient.all.order(:first_name, :last_name)
   end
 
+  def create
+    contact = Contact.find(params[:contact_id])
+
+    ApplicationRecord.transaction do
+      patient = contact.create_patient!({
+        first_name: contact.first_name,
+        last_name: contact.last_name,
+        avatar_url: Contact::DEFAULT_AVATAR_URL,
+      })
+      contact.save!
+  
+      flash[:info] = "Created patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
+    end
+
+
+    redirect_to controller: :contacts, action: :index
+  end
+
   def sync
     @patient = Patient.find(params[:id])
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,4 +1,6 @@
 class PatientsController < ApplicationController
+  rescue_from PatientSyncService::SyncError, with: :flash_sync_error
+  
   def index
     @patients = Patient.all.order(:first_name, :last_name)
   end
@@ -9,6 +11,13 @@ class PatientsController < ApplicationController
     PatientSyncService.new(@patient).sync
 
     flash[:info] = "Synced patient '#{@patient.first_name} #{@patient.last_name}' with Sicklie"
+    redirect_to action: :index
+  end
+
+  private
+
+  def flash_sync_error(error)
+    flash[:danger] = error.message
     redirect_to action: :index
   end
 end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -6,13 +6,7 @@ class PatientsController < ApplicationController
   end
 
   def create
-    contact = Contact.find(params[:contact_id])
-
-    patient = contact.create_patient!({
-      first_name: contact.first_name,
-      last_name: contact.last_name,
-      avatar_url: Contact::DEFAULT_AVATAR_URL,
-    })
+    patient = Contact.find(params[:contact_id]).create_patient!
 
     flash[:info] = "Created patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,3 @@
+class Contact < ApplicationRecord
+  belongs_to :patient, optional: true
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,6 +3,9 @@ class Contact < ApplicationRecord
 
   belongs_to :patient, optional: true
 
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+
   def create_patient!(attributes = {})
     super({
       first_name: first_name,

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,3 +1,5 @@
 class Contact < ApplicationRecord
+  DEFAULT_AVATAR_URL="https://robohash.org/quitotamnon.png?size=300x300&set=set1"
+
   belongs_to :patient, optional: true
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -2,4 +2,12 @@ class Contact < ApplicationRecord
   DEFAULT_AVATAR_URL="https://robohash.org/quitotamnon.png?size=300x300&set=set1"
 
   belongs_to :patient, optional: true
+
+  def create_patient!(attributes = {})
+    super({
+      first_name: first_name,
+      last_name: last_name,
+      avatar_url: DEFAULT_AVATAR_URL,
+    }.merge(attributes))
+  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,2 +1,3 @@
 class Patient < ApplicationRecord
+  has_one :contact, autosave: true
 end

--- a/app/services/patient_sync_service.rb
+++ b/app/services/patient_sync_service.rb
@@ -15,6 +15,8 @@ class PatientSyncService
           sicklie_id: result[:sicklie_id],
           sicklie_updated_at: Time.current
         )
+      else
+        raise SyncError, result
       end
     else
       result = SicklieApi.update_patient(
@@ -24,7 +26,15 @@ class PatientSyncService
       )
       if result.is_a?(Hash) && result[:status_code] == "SUCCESS"
         @patient.update!(sicklie_updated_at: Time.current)
-      end      
+      else
+        raise SyncError.new(result)
+      end
+    end
+  end
+
+  class SyncError < StandardError
+    def initialize(result)
+      super("Error syncing with Sicklie: #{result}")
     end
   end
 end

--- a/app/services/patient_sync_service.rb
+++ b/app/services/patient_sync_service.rb
@@ -5,33 +5,47 @@ class PatientSyncService
 
   def sync
     if @patient.sicklie_id.blank?
-      result = SicklieApi.create_patient(
-        first_name: @patient.first_name, 
-        last_name: @patient.last_name
-      )
-
-      if result.is_a?(Hash) && result[:status_code] == "SUCCESS"
-        @patient.update!(
-          sicklie_id: result[:sicklie_id],
-          sicklie_updated_at: Time.current
-        )
-      else
-        raise SyncError, result
-      end
+      create_patient
     else
-      result = SicklieApi.update_patient(
-        sicklie_id: @patient.sicklie_id, 
-        first_name: @patient.first_name, 
-        last_name: @patient.last_name
-      )
-      if result.is_a?(Hash) && result[:status_code] == "SUCCESS"
-        @patient.update!(sicklie_updated_at: Time.current)
-      else
-        raise SyncError.new(result)
-      end
+      update_patient
     end
   end
 
+  private
+
+  def create_patient
+    result = SicklieApi.create_patient(
+      first_name: @patient.first_name, 
+      last_name: @patient.last_name
+    )
+
+    handle_result(result)
+  end
+
+  def update_patient
+    result = SicklieApi.update_patient(
+      sicklie_id: @patient.sicklie_id, 
+      first_name: @patient.first_name, 
+      last_name: @patient.last_name
+    )
+
+    handle_result(result)
+  end
+
+  def handle_result(result)
+    if result.is_a?(Hash) && result[:status_code] == "SUCCESS"
+      attributes = { sicklie_updated_at: Time.current }
+      
+      if sicklie_id = result[:sicklie_id]
+        attributes[:sicklie_id] = sicklie_id
+      end
+      
+      @patient.update!(attributes)
+    else
+      raise SyncError, result
+    end
+  end
+  
   class SyncError < StandardError
     def initialize(result)
       super("Error syncing with Sicklie: #{result}")

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 my-4 justify-items-center">
   <% @contacts.each do |contact| %>
-    <%= render CardComponent.new do %>
-      <h5 class="mb-1 text-xl font-medium text-gray-900">
-        <%= render FullNameComponent.new(contact) %>
-      </h5>      
+    <% if contact.patient %>
+      <%= render PatientCardComponent.new(contact.patient) %>
+    <% else %>
+      <%= render ContactCardComponent.new(contact) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,0 +1,11 @@
+<h2 class="text-lg sm:text-2xl font-extrabold">Contact Directory</h2>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 my-4 justify-items-center">
+  <% @contacts.each do |contact| %>
+    <%= render CardComponent.new do %>
+      <h5 class="mb-1 text-xl font-medium text-gray-900">
+        <%= render FullNameComponent.new(contact) %>
+      </h5>      
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -2,19 +2,6 @@
 
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 my-4 justify-items-center">
   <% @patients.each do |patient| %>
-    <%= render CardComponent.new do %>
-      <%= render AvatarComponent.new(avatar_url: patient.avatar_url) %>
-      <h5 class="mb-1 text-xl font-medium text-gray-900">
-        <%= render FullNameComponent.new(patient) %>
-      </h5>
-      
-      <%= render TimestampComponent.new(patient.sicklie_updated_at, "Not registered with Sicklie") %>
-
-      <div class="flex mt-4 space-x-3 md:mt-6">
-        <%= form_with url: sync_patient_path(patient), method: :put do |form| %>
-          <%= form.button "Sync", class: "inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300" %>
-        <% end %>
-      </div>    
-    <% end %>
+    <%= render PatientCardComponent.new(patient) %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :contacts
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/db/migrate/20240311155850_create_contacts.rb
+++ b/db/migrate/20240311155850_create_contacts.rb
@@ -7,5 +7,7 @@ class CreateContacts < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
+
+    add_index :contacts, [:first_name, :last_name]
   end
 end

--- a/db/migrate/20240311155850_create_contacts.rb
+++ b/db/migrate/20240311155850_create_contacts.rb
@@ -1,0 +1,11 @@
+class CreateContacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contacts do |t|
+      t.string :first_name
+      t.string :last_name
+      t.references :patient, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240311155850_create_contacts.rb
+++ b/db/migrate/20240311155850_create_contacts.rb
@@ -1,8 +1,8 @@
 class CreateContacts < ActiveRecord::Migration[7.0]
   def change
     create_table :contacts do |t|
-      t.string :first_name
-      t.string :last_name
+      t.string :first_name, null: false
+      t.string :last_name, null: false
       t.references :patient, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema[7.0].define(version: 2024_03_11_155850) do
   create_table "contacts", force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
     t.integer "patient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_02_173003) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_11_155850) do
+  create_table "contacts", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.integer "patient_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["patient_id"], name: "index_contacts_on_patient_id"
+  end
+
   create_table "patients", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -21,4 +30,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_173003) do
     t.datetime "sicklie_updated_at"
   end
 
+  add_foreign_key "contacts", "patients"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_155850) do
     t.integer "patient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["first_name", "last_name"], name: "index_contacts_on_first_name_and_last_name"
     t.index ["patient_id"], name: "index_contacts_on_patient_id"
   end
 

--- a/db/seeds/contacts.rb
+++ b/db/seeds/contacts.rb
@@ -1,0 +1,7 @@
+10.times do
+  FactoryBot.create(:contact)
+end
+
+5.times do
+  FactoryBot.create(:contact, :with_patient)
+end

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-RSpec.describe PatientsController, type: :controller do
-  describe "GET index" do
-    it "displays the contacts" do
-      
-    end
-  end
-end

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe PatientsController, type: :controller do
+  describe "GET index" do
+    it "displays the contacts" do
+      
+    end
+  end
+end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe PatientsController, type: :controller do
+  describe "PUT sync" do
+    let(:patient_sicklie_id) { SecureRandom.uuid }
+    let(:patient) { FactoryBot.create(:patient, sicklie_id: patient_sicklie_id) }
+
+    let(:mock_patient_sync_service) { instance_double(PatientSyncService, sync: nil) }
+
+    before do
+      allow(PatientSyncService).to receive(:new).with(patient).and_return mock_patient_sync_service
+    end
+
+    it "adds an info flash to indicate success" do
+      put :sync, params: { id: patient.id }
+
+      expect(flash[:info]).to match "Synced patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
+    end
+  end
+end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe PatientsController, type: :controller do
       put :sync, params: { id: patient.id }
 
       expect(flash[:info]).to match "Synced patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
+        expect(response).to redirect_to patients_path
+    end
+
+    context "there is an error syncing with Sicklie" do
+      let(:error) { PatientSyncService::SyncError.new("There was an error") }
+
+      before do
+        allow(mock_patient_sync_service).to receive(:sync).and_raise error
+      end
+
+      it "adds an error flash to indicate the error" do
+        put :sync, params: { id: patient.id }
+
+        expect(flash[:danger]).to match "Error syncing with Sicklie: There was an error"
+        expect(response).to redirect_to patients_path
+      end
     end
   end
 end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -33,4 +33,17 @@ RSpec.describe PatientsController, type: :controller do
       end
     end
   end
+
+  describe "POST index" do
+    let!(:contact) { FactoryBot.create(:contact) }
+
+    it "creates a patient from the contact" do
+      expect { post :create, params: { contact_id: contact.id } }.to change(Patient, :count).by(1)
+      expect(contact.reload.patient.attributes).to include({
+        "first_name" => contact.first_name,
+        "last_name" => contact.last_name,
+        "avatar_url" => Contact::DEFAULT_AVATAR_URL,
+      })
+    end
+  end
 end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :contact do
+    first_name { "MyString" }
+    last_name { "MyString" }
+    patient { nil }
+  end
+end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :contact do
-    first_name { "MyString" }
-    last_name { "MyString" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
     patient { nil }
+
+    trait :with_patient do
+      patient { association :patient, first_name: first_name, last_name: last_name }
+    end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Contact, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#create_patient!" do
+    let!(:contact) { FactoryBot.create(:contact) }
+
+    it "creates a patient with the same first and last name as the contact and the default avatar URL" do
+      expect { contact.create_patient! }.to change(Patient, :count).by(1)
+      expect(contact.patient.first_name).to eql(contact.first_name)
+      expect(contact.patient.last_name).to eql(contact.last_name)
+      expect(contact.patient.avatar_url).to eql(Contact::DEFAULT_AVATAR_URL)
+    end
+
+    it "merges defaults with any attributes it gets" do
+      contact.create_patient!(last_name: "Cameron")
+
+      expect(contact.patient.first_name).to eql(contact.first_name)
+      expect(contact.patient.last_name).to eql("Cameron")
+      expect(contact.patient.avatar_url).to eql(Contact::DEFAULT_AVATAR_URL)
+    end
+  end
 end

--- a/spec/services/patient_sync_service_spec.rb
+++ b/spec/services/patient_sync_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PatientSyncService, type: :service do
 
     before { freeze_time }
 
-    shared_examples "handles errors" do
+    shared_examples "raises exceptions on errors" do
       describe "error handling" do
         before do
           allow(SicklieApi).to receive(:create_patient).and_return api_response
@@ -62,7 +62,7 @@ RSpec.describe PatientSyncService, type: :service do
         )
       end
 
-      it_behaves_like "handles errors"
+      it_behaves_like "raises exceptions on errors"
     end
 
     context "when the patient has a sicklie_id" do
@@ -89,7 +89,7 @@ RSpec.describe PatientSyncService, type: :service do
         )
       end
 
-      it_behaves_like "handles errors"
+      it_behaves_like "raises exceptions on errors"
     end    
   end
 end

--- a/spec/services/patient_sync_service_spec.rb
+++ b/spec/services/patient_sync_service_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe PatientSyncService, type: :service do
           let(:api_response) { "Internal server error" }
 
           it "throws an error containing the message" do
-            expect { call }.to raise_error PatientSyncService::SyncError, "Error syncing with Sicklie: Internal server error"
+            expect { call }.to raise_error PatientSyncService::SyncError, 
+              "Error syncing with Sicklie: Internal server error"
           end
         end
 


### PR DESCRIPTION
Adds error handling to the patient sync process. As this seems to be internally facing and the requirement was to "show anything they tell us", I elected to include the error responses verbatim. If I had access to the Product Owner when working on this, I would have consulted with them to sort out the details of how to best present this in a more user friendly way, depending on who the user is (this is great for an engineer, less great to dump a hash in a flash message shown to a less technical user).

Adds a contacts index which allows for creating patients from contacts, as well as syncing patients already created from contacts. One note on this: to me, it feels a bit odd that syncing a patient from the Contacts index redirects you to the Patients index (especially because they look so similar). This is another talking point I would probably bring back to a Product Owner when working on this.